### PR TITLE
Fix role usage in auth controller tests

### DIFF
--- a/src/auth/dto/create-auth.dto.ts
+++ b/src/auth/dto/create-auth.dto.ts
@@ -1,5 +1,5 @@
 import { IsEmail, IsString, IsNotEmpty, MinLength } from 'class-validator';
-import { Role } from 'src/constants/roles';
+import { ROLES } from 'src/constants/roles';
 import { IsValidRole } from 'src/common/decorators/roles.decorator';
 
 export class CreateAuthDto {
@@ -11,7 +11,7 @@ export class CreateAuthDto {
   public name: string;
 
   @IsValidRole()
-  public role: Role;
+  public role: keyof typeof ROLES;
 
   @IsString()
   @IsNotEmpty()

--- a/test/auth.controller.spec.ts
+++ b/test/auth.controller.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from '../src/auth/auth.controller';
 import { AuthService } from '../src/auth/auth.service';
 import { CreateAuthDto } from '../src/auth/dto/create-auth.dto';
-import { Role } from '../src/constants/roles';
+import { ROLES } from '../src/constants/roles';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -36,7 +36,7 @@ describe('AuthController', () => {
       const dto: CreateAuthDto = {
         email: 'test@example.com',
         name: 'Test User',
-        role: Role.CASHIER,
+        role: ROLES.CASHIER,
         password: 'password123',
       };
       await controller.register(dto);
@@ -47,7 +47,7 @@ describe('AuthController', () => {
       const dto: CreateAuthDto = {
         email: 'test@example.com',
         name: 'Test User',
-        role: Role.CASHIER,
+        role: ROLES.CASHIER,
         password: 'password123',
       };
       const result = { id: 1, ...dto, createdAt: new Date(), updatedAt: new Date(), isActive: true };
@@ -61,7 +61,7 @@ describe('AuthController', () => {
       const dto: CreateAuthDto = {
         email: 'test@example.com',
         name: 'Test User',
-        role: Role.CASHIER,
+        role: ROLES.CASHIER,
         password: 'password123',
       };
       await controller.login(dto);
@@ -72,7 +72,7 @@ describe('AuthController', () => {
       const dto: CreateAuthDto = {
         email: 'test@example.com',
         name: 'Test User',
-        role: Role.CASHIER,
+        role: ROLES.CASHIER,
         password: 'password123',
       };
       jest.spyOn(service, 'validateUser').mockResolvedValue(null);
@@ -83,7 +83,7 @@ describe('AuthController', () => {
       const dto: CreateAuthDto = {
         email: 'test@example.com',
         name: 'Test User',
-        role: Role.CASHIER,
+        role: ROLES.CASHIER,
         password: 'password123',
       };
       const user = { id: 1, ...dto };


### PR DESCRIPTION
Update `CreateAuthDto` and `auth.controller.spec.ts` to use `ROLES` instead of `Role`.

* **CreateAuthDto**:
  - Import `ROLES` instead of `Role` from `src/constants/roles`.
  - Change the type of `role` to `keyof typeof ROLES`.

* **auth.controller.spec.ts**:
  - Import `ROLES` instead of `Role` from `src/constants/roles`.
  - Change the `role` property in the `CreateAuthDto` instances to `ROLES.CASHIER`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Bacze12/inventory-pos/pull/19?shareId=cd091ffa-5994-4a37-a455-041d176c36d3).