### PR TITLE
Fix syntax error in users.controller.spec.ts

### DIFF
--- a/test/users.controller.spec.ts
+++ b/test/users.controller.spec.ts
@@ -145,4 +145,4 @@ describe('UsersController', () => {
       expect(await controller.reactivate(+id)).toBe(result);
     });
   });
-}
+});


### PR DESCRIPTION
Fix syntax error in `test/users.controller.spec.ts`.

* Add missing closing parenthesis to ensure the test file runs without errors.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Bacze12/inventory-pos/pull/21?shareId=714f2f9b-cfea-4fc0-b7b6-aba6cb076d64).