### PR TITLE
Fix deployment issues with Node.js version and module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "",
   "author": "",
-  "type":"module",
+  "type": "commonjs",
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
@@ -13,7 +13,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/src/main",
+    "start:prod": "node dist/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.js",
     "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",

--- a/render.yml
+++ b/render.yml
@@ -1,10 +1,9 @@
-
 services:
   - type: web
     name: inventory-pos-api
     env: node
     buildCommand: npm install && npm run build:prod
-    startCommand: npm run start:prod
+    startCommand: node dist/main.js
     envVars:
       - key: DATABASE_URL
         fromDatabase:

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,8 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { dynamicRateLimitMiddleware } from './middleware/rate-limit.middleware';
-import * as fs from 'fs';
-import * as yaml from 'js-yaml';
+const fs = require('fs');
+const yaml = require('js-yaml');
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "types": ["node", "jest"],
-    "module": "commonjs",
+    "module": "ESNext",
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
Update the project to use CommonJS modules instead of ES modules.

* **package.json**
  - Change the `type` field from `"module"` to `"commonjs"`.
  - Update the `start:prod` script to use `node dist/main.js` instead of `node dist/src/main`.

* **tsconfig.json**
  - Change the `module` field from `"commonjs"` to `"ESNext"`.

* **src/main.ts**
  - Change the import statement for `fs` to use `require` instead of `import`.
  - Change the import statement for `yaml` to use `require` instead of `import`.

* **render.yml**
  - Update the `startCommand` to use `node dist/main.js` instead of `npm run start:prod`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Bacze12/inventory-pos/pull/30?shareId=30f0823a-a47d-4453-a79c-833055ef26a3).